### PR TITLE
chore: make sed invocation start task cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "proxy": "http://localhost:8080",
   "scripts": {
-    "start": "sed -i '' -e 's/compress: true/compress: false/' ./node_modules/react-scripts/config/webpackDevServer.config.js && react-app-rewired start",
+    "start": "sed -i.bak -e 's/compress: true/compress: false/' ./node_modules/react-scripts/config/webpackDevServer.config.js && react-app-rewired start",
     "start:mock": "REACT_APP_MOCK_DATA=true yarn start",
     "build": "react-app-rewired build",
     "test": "react-app-rewired test",


### PR DESCRIPTION
Apparently `-i ''` works only on Mac and not Linux and there's no way to make it cross-platform which is megadumb